### PR TITLE
fix for https://github.com/hashicorp/terraform-provider-aws/issues/4852

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ ecs_additional_iam_statements = [
 | cluster_arn | The ECS cluster ARN |
 | cluster_asg_name | The ECS cluster Auto Scaling Group name, used to attach Auto Scaling Policies |
 | cluster_asg_arn | The ECS cluster Auto Scaling Group arn, used for ECS capacity providers |
+| cluster_aws_launch_configuration_name | The ECS cluster AutoScaling Group aws_launch_configuration Name |
 | cluster_iam_role_arn | The ECS cluster IAM role ARN, useful for attaching to ECR repos |
 
 ## Authors

--- a/outputs.tf
+++ b/outputs.tf
@@ -2,21 +2,31 @@
 # Outputs
 #------------------------------------------------------------------------------
 output "cluster_id" {
-  value = aws_ecs_cluster.this.id
+  description = "Cluster ID"
+  value       = aws_ecs_cluster.this.id
 }
 
 output "cluster_arn" {
-  value = aws_ecs_cluster.this.arn
+  description = "Cluster ARN"
+  value       = aws_ecs_cluster.this.arn
 }
 
 output "cluster_asg_name" {
-  value = aws_autoscaling_group.this.name
+  description = "Cluster AutoScaling Group Name"
+  value       = aws_autoscaling_group.this.name
 }
 
 output "cluster_asg_arn" {
-  value = aws_autoscaling_group.this.arn
+  description = "Cluster AutoScaling Group ARN"
+  value       = aws_autoscaling_group.this.arn
 }
 
 output "cluster_iam_role_arn" {
-  value = aws_iam_role.this.arn
+  description = "Cluster IAM role ARN"
+  value       = aws_iam_role.this.arn
+}
+
+output "cluster_aws_launch_configuration_name" {
+  description = "Cluster AutoScaling Group aws_launch_configuration Name"
+  value       = aws_launch_configuration.this.name
 }


### PR DESCRIPTION
(The Cluster cannot be deleted/renamed while Container Instances are active or draining. )
+ attempt to inverse dependencies on efs_sg_ids and efs_id for ASG aws_launch_configuration