### PR TITLE
Feature/sysctl in user data

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ ecs_additional_iam_statements = [
 | cluster_arn | The ECS cluster ARN |
 | cluster_asg_name | The ECS cluster Auto Scaling Group name, used to attach Auto Scaling Policies |
 | cluster_asg_arn | The ECS cluster Auto Scaling Group arn, used for ECS capacity providers |
+| cluster_aws_launch_configuration_name | The ECS cluster AutoScaling Group aws_launch_configuration Name |
 | cluster_iam_role_arn | The ECS cluster IAM role ARN, useful for attaching to ECR repos |
 
 ## Authors

--- a/main.tf
+++ b/main.tf
@@ -21,6 +21,16 @@ data "template_file" "user_data" {
     efs_id           = var.efs_id
     http_proxy       = var.http_proxy
     http_proxy_port  = var.http_proxy_port
+    system_controls  = join("\n", data.template_file.sysctl.*.rendered)
+  }
+}
+
+data "template_file" "sysctl" {
+  count    = length(var.system_controls)
+  template = file("${path.module}/system_controls.tpl")
+  vars = {
+    key   = var.system_controls[count.index].name
+    value = var.system_controls[count.index].value
   }
 }
 
@@ -39,6 +49,13 @@ resource "null_resource" "tags_as_list_of_maps" {
     "key"                 = keys(var.tags)[count.index]
     "value"               = values(var.tags)[count.index]
     "propagate_at_launch" = "true"
+  }
+}
+
+#DBG user_data, might be useful to keep representation in state for reference.
+resource "null_resource" "user_data_rendered_view" {
+  triggers = {
+    user_data = data.template_file.user_data.rendered
   }
 }
 

--- a/outputs.tf
+++ b/outputs.tf
@@ -2,21 +2,31 @@
 # Outputs
 #------------------------------------------------------------------------------
 output "cluster_id" {
-  value = aws_ecs_cluster.this.id
+  description = "Cluster ID"
+  value       = aws_ecs_cluster.this.id
 }
 
 output "cluster_arn" {
-  value = aws_ecs_cluster.this.arn
+  description = "Cluster ARN"
+  value       = aws_ecs_cluster.this.arn
 }
 
 output "cluster_asg_name" {
-  value = aws_autoscaling_group.this.name
+  description = "Cluster AutoScaling Group Name"
+  value       = aws_autoscaling_group.this.name
 }
 
 output "cluster_asg_arn" {
-  value = aws_autoscaling_group.this.arn
+  description = "Cluster AutoScaling Group ARN"
+  value       = aws_autoscaling_group.this.arn
 }
 
 output "cluster_iam_role_arn" {
-  value = aws_iam_role.this.arn
+  description = "Cluster IAM role ARN"
+  value       = aws_iam_role.this.arn
+}
+
+output "cluster_aws_launch_configuration_name" {
+  description = "Cluster AutoScaling Group aws_launch_configuration Name"
+  value       = aws_launch_configuration.this.name
 }

--- a/system_controls.tpl
+++ b/system_controls.tpl
@@ -1,0 +1,1 @@
+%{ if key != "" }bash -c 'echo ${key}=${value} >> /etc/sysctl.conf'%{ endif }

--- a/user_data.tpl
+++ b/user_data.tpl
@@ -99,6 +99,13 @@ EOF
     echo "$$: $(date +%s.%N | cut -b1-13)" > /var/lib/cloud/instance/sem/config_ecs-init_http_proxy
 fi
 %{ endif }
+%{ if system_controls != "" }
+--==BOUNDARY==
+Content-Type: text/x-shellscript; charset="us-ascii"
+#!/bin/bash
+${system_controls}
+sysctl -p
+%{ endif }
 --==BOUNDARY==
 Content-Type: text/x-shellscript; charset="us-ascii"
 
@@ -107,3 +114,5 @@ Content-Type: text/x-shellscript; charset="us-ascii"
 echo "ECS_CLUSTER=${ecs_cluster_name}" >> /etc/ecs/ecs.config
 
 --==BOUNDARY==--
+
+

--- a/variables.tf
+++ b/variables.tf
@@ -114,3 +114,12 @@ variable "http_proxy_port" {
   type        = number
   default     = 3128
 }
+
+variable "system_controls" {
+  description = "A list of node-level sysctls kernel parameters to set on the container instance"
+  type = list(object({
+    name  = string
+    value = string
+  }))
+  default = []
+}


### PR DESCRIPTION
Adds ability to pass custom sysctl options to ec2 container instances, as oppose to [systemControls](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task_definition_parameters.html#container_definition_systemcontrols) (which manage namespaced only controls for container)
gives ability to manage docker host system controls.

provides ability to set user-data e.g.:

```bash
                Content-Type: multipart/mixed; boundary="==BOUNDARY=="
                MIME-Version: 1.0              
                               
                --==BOUNDARY==
                Content-Type: text/x-shellscript; charset="us-ascii"
                #!/bin/bash
                bash -c 'echo fs.file-max=2097152 >> /etc/sysctl.conf'
                bash -c 'echo vm.max_map_count=262144 >> /etc/sysctl.conf'
                bash -c 'echo vm.swappiness=1 >> /etc/sysctl.conf'
                sysctl -p
                
                --==BOUNDARY==
                Content-Type: text/x-shellscript; charset="us-ascii"
                
                #!/bin/bash
                # Set any ECS agent configuration options
                echo "ECS_CLUSTER=sandbox-test-ecs-cluster" >> /etc/ecs/ecs.config
                
                --==BOUNDARY==--
                
```