### PR TITLE
Adding a new var for cleanup of containers.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 - repo: git://github.com/antonbabenko/pre-commit-terraform
-  rev: v1.62.0
+  rev: v1.62.3
   hooks:
     - id: terraform_fmt
     - id: terraform_validate

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ ecs_additional_iam_statements = [
 
 | Name | Version |
 |------|---------|
-| aws | 3.74.0 |
+| aws | 4.3.0 |
 | null | 3.1.0 |
 
 ## Modules
@@ -114,6 +114,7 @@ No modules.
 | ecs\_capacity\_provider\_target | Percentage target of capacity to get to before triggering scaling | `number` | `90` | no |
 | ecs\_cidr\_block | ECS CIDR block | `list(string)` | n/a | yes |
 | ecs\_desired\_capacity | Desired number of EC2 instances. | `number` | `1` | no |
+| ecs\_engine\_task\_cleanup\_wait\_duration | Time to wait from when a task is stopped until the Docker container is removed. As this removes the Docker container data, be aware that if this value is set too low, you may not be able to inspect your stopped containers or view the logs before they are removed. The minimum duration is 1m; any value shorter than 1 minute is ignored. | `string` | `"3h"` | no |
 | ecs\_instance\_type | Default instance type | `string` | `"t3.medium"` | no |
 | ecs\_key\_name | SSH key name in your AWS account for AWS instances. | `string` | `""` | no |
 | ecs\_max\_size | Maximum number of EC2 instances. | `number` | `1` | no |

--- a/main.tf
+++ b/main.tf
@@ -13,10 +13,11 @@ locals {
   tags_asg_format = null_resource.tags_as_list_of_maps.*.triggers
   user_data = templatefile("${path.module}/user_data.tpl",
     {
-      ecs_cluster_name = var.ecs_name
-      efs_id           = var.efs_id
-      http_proxy       = var.http_proxy
-      http_proxy_port  = var.http_proxy_port
+      ecs_cluster_name                      = var.ecs_name
+      efs_id                                = var.efs_id
+      http_proxy                            = var.http_proxy
+      http_proxy_port                       = var.http_proxy_port
+      ecs_engine_task_cleanup_wait_duration = var.ecs_engine_task_cleanup_wait_duration
     }
   )
 }

--- a/user_data.tpl
+++ b/user_data.tpl
@@ -78,6 +78,7 @@ echo "ECS_CLUSTER=${ecs_cluster_name}" >> /etc/ecs/ecs.config
 echo "ECS_IMAGE_PULL_BEHAVIOR=always" >> /etc/ecs/ecs.config
 echo "ECS_ENABLE_UNTRACKED_IMAGE_CLEANUP=true" >> /etc/ecs/ecs.config
 echo "ECS_ENABLE_SPOT_INSTANCE_DRAINING=true" >> /etc/ecs/ecs.config
+echo "ECS_ENABLE_SPOT_INSTANCE_DRAINING=${ecs_engine_task_cleanup_wait_duration}" >> /etc/ecs/ecs.config
 systemctl enable --now --no-block ecs.service
 systemctl enable --now --no-block amazon-ecs-volume-plugin.service
 --==BOUNDARY==--

--- a/variables.tf
+++ b/variables.tf
@@ -162,3 +162,13 @@ variable "ecs_wait_for_capacity_timeout" {
   type        = string
   default     = "20m"
 }
+
+variable "ecs_engine_task_cleanup_wait_duration" {
+  description = <<-EOT
+  Time to wait from when a task is stopped until the Docker container is removed. As this removes the Docker container
+  data, be aware that if this value is set too low, you may not be able to inspect your stopped containers or view the
+  logs before they are removed. The minimum duration is 1m; any value shorter than 1 minute is ignored.
+  EOT
+  type        = string
+  default     = "3h"
+}


### PR DESCRIPTION
Adding a new var that follows the documented default for the clean up of
containers.

Also dropped the version of the pre-commit hooks as there are
compatibility issues with the latest release.