### PR TITLE
Removing the KMS config for volumes.

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,6 @@ No modules.
 | [aws_security_group.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) | resource |
 | [null_resource.asg-scale-to-0-on-destroy](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) | resource |
 | [null_resource.tags_as_list_of_maps](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) | resource |
-| [aws_ebs_default_kms_key.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ebs_default_kms_key) | data source |
 | [aws_iam_policy_document.assume_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_ssm_parameter.ecs_ami](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ssm_parameter) | data source |

--- a/main.tf
+++ b/main.tf
@@ -6,8 +6,6 @@ data "aws_ssm_parameter" "ecs_ami" {
   name = "/aws/service/ecs/optimized-ami/amazon-linux-2/recommended/image_id"
 }
 
-data "aws_ebs_default_kms_key" "current" {}
-
 #------------------------------------------------------------------------------
 # Local Values
 #------------------------------------------------------------------------------
@@ -151,7 +149,6 @@ resource "aws_launch_template" "this" {
       volume_size = var.ecs_volume_size
       volume_type = var.ecs_volume_type
       encrypted   = true
-      kms_key_id  = data.aws_ebs_default_kms_key.current.id
     }
   }
 


### PR DESCRIPTION
The default will use the default EBS key anyway and this was incorrectly
configured.